### PR TITLE
Add Python headers supporting ensime-vim test deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ ENV PATH /root/.cask/bin:${PATH}
 ################################################
 # ensime-vim
 RUN\
-  apt-get install -yy make g++ gcc openssl libssl-dev ruby ruby-dev python-mock python-pip &&\
+  apt-get install -yy make g++ gcc openssl libssl-dev ruby ruby-dev python-dev python-mock python-pip &&\
   pip install websocket-client &&\
   gem install bundle &&\
   apt-get clean


### PR DESCRIPTION
I tried adding a test dependency [that turns out to depend on the Python development headers](http://fommil.com/ensime/ensime-vim/284). It's an optional dep so we can live without it, but if it's not a big deal to add the devel package then it is a performance improvement for Gherkin tests and all their string matching.

By the way, I believe #2 can be closed now 😄 

ensime/ensime-vim#287
